### PR TITLE
Support all Visual Studio 2019 (VS 16) versions

### DIFF
--- a/CollapseAndSync/source.extension.vsixmanifest
+++ b/CollapseAndSync/source.extension.vsixmanifest
@@ -11,11 +11,11 @@
     <Tags>Navigation, Solution Explorer</Tags>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[11.0,17.0)" Id="Microsoft.VisualStudio.Ultimate" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/CollapseAndSync/source.extension.vsixmanifest
+++ b/CollapseAndSync/source.extension.vsixmanifest
@@ -11,7 +11,7 @@
     <Tags>Navigation, Solution Explorer</Tags>
   </Metadata>
   <Installation InstalledByMsi="false">
-    <InstallationTarget Version="[11.0,16.0]" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Community" />
     <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
     <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
     <InstallationTarget Version="[11.0,16.0)" Id="Microsoft.VisualStudio.Premium" />


### PR DESCRIPTION
Currently the extension can only be installed on VS 2019 community 16.0, so basically every minor update afterwards would make it incompatible. In addition to that the version ranges specified in the manifest were not consistent. This resulted in the extension effectively not supporting VS2019 Professional (etc)

I've been using the updated version of CollapseAndSync for several weeks now. There don't seem to be any incompatibilities with VS 2019 version 16.6, so at this point it is safe to assume that all VS versions up to 17 will not break anything.